### PR TITLE
Restrict publish workflows to main branch only

### DIFF
--- a/.github/workflows/04_dotnetpublish_01_proxy.yml
+++ b/.github/workflows/04_dotnetpublish_01_proxy.yml
@@ -3,8 +3,8 @@ on:
     workflow_run:
         workflows: ["04_dotnetpublish_00_buildRelease"] # Wait for this workflow by name
         types: [completed] # Trigger when it completes
-        branches: ["main", "Develop"] # Only for these branches
-
+        branches: ["main"] # Only for these branches
+# , "Develop"
 # Special permissions required for OIDC authentication
 permissions:
     id-token: write

--- a/.github/workflows/04_dotnetpublish_01_storage.yml
+++ b/.github/workflows/04_dotnetpublish_01_storage.yml
@@ -1,39 +1,39 @@
 name: 04_dotnetpublish_01_storage
 on:
-    workflow_run:
-        workflows: ["04_dotnetpublish_00_buildRelease"] # Wait for this workflow by name
-        types: [completed] # Trigger when it completes
-        branches: ["main", "Develop"] # Only for these branches
+  workflow_run:
+    workflows: ["04_dotnetpublish_00_buildRelease"] # Wait for this workflow by name
+    types: [completed] # Trigger when it completes
+    branches: ["main"] # Only for these branches
 permissions:
-    id-token: write
-    contents: read
+  id-token: write
+  contents: read
 jobs:
-    download-and-publish-storage:
-        runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if build succeeded
-        environment: Personal_Azure
+  download-and-publish-storage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if build succeeded
+    environment: Personal_Azure
 
-        steps:
-            - name: Download proxy artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: storage-artifact
-                  path: .
-                  github-token: ${{ secrets.GITHUB_TOKEN }} # Auth to download from another workflow
-                  run-id: ${{ github.event.workflow_run.id }} # Download from THAT specific build run
-            - name: Display structure of downloaded files
-              run: ls -R
-            - name: Login to Azure
-              uses: azure/login@v2
-              with:
-                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
-                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Download proxy artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: storage-artifact
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Auth to download from another workflow
+          run-id: ${{ github.event.workflow_run.id }} # Download from THAT specific build run
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-            - name: Deploy to Azure Web App
-              id: deploy-to-webapp
-              uses: azure/webapps-deploy@v3
-              with:
-                  app-name: "WebAppsStorage"
-                  slot-name: "Production"
-                  package: .
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: "WebAppsStorage"
+          slot-name: "Production"
+          package: .

--- a/.github/workflows/04_dotnetpublish_01_store.yml
+++ b/.github/workflows/04_dotnetpublish_01_store.yml
@@ -1,39 +1,39 @@
 name: 04_dotnetpublish_01_store
 on:
-    workflow_run:
-        workflows: ["04_dotnetpublish_00_buildRelease"] # Wait for this workflow by name
-        types: [completed] # Trigger when it completes
-        branches: ["main", "Develop"] # Only for these branches
+  workflow_run:
+    workflows: ["04_dotnetpublish_00_buildRelease"] # Wait for this workflow by name
+    types: [completed] # Trigger when it completes
+    branches: ["main"] # Only for these branches
 permissions:
-    id-token: write
-    contents: read
+  id-token: write
+  contents: read
 jobs:
-    download-and-publish-store:
-        runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if build succeeded
-        environment: Personal_Azure
+  download-and-publish-store:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if build succeeded
+    environment: Personal_Azure
 
-        steps:
-            - name: Download proxy artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: store-artifact
-                  path: .
-                  github-token: ${{ secrets.GITHUB_TOKEN }} # Auth to download from another workflow
-                  run-id: ${{ github.event.workflow_run.id }} # Download from THAT specific build run
-            - name: Display structure of downloaded files
-              run: ls -R
-            - name: Login to Azure
-              uses: azure/login@v2
-              with:
-                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
-                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Download proxy artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: store-artifact
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Auth to download from another workflow
+          run-id: ${{ github.event.workflow_run.id }} # Download from THAT specific build run
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-            - name: Deploy to Azure Web App
-              id: deploy-to-webapp
-              uses: azure/webapps-deploy@v3
-              with:
-                  app-name: "WebAppsStore"
-                  slot-name: "Production"
-                  package: .
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: "WebAppsStore"
+          slot-name: "Production"
+          package: .


### PR DESCRIPTION
Updated the dotnet publish workflows for proxy, storage, and store to trigger only on the 'main' branch instead of both 'main' and 'Develop'. This change helps prevent unintended deployments from non-production branches.