### PR TITLE
Update workflows and clean up ProductsActions imports

### DIFF
--- a/.github/workflows/01_reactBuild.yml
+++ b/.github/workflows/01_reactBuild.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
       #upload  build result
       - name: Archive production artifacts
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: react-artifact

--- a/.github/workflows/04_dotnetpublish_00_buildRelease.yml
+++ b/.github/workflows/04_dotnetpublish_00_buildRelease.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   call-tests-workflow-from-build-release:
     uses: "./.github/workflows/03_dotnet_02_BuildAndRunTests.yml"
+  call-build-react:
+    # will only build the react project and check that everything is fine
+    if: github.ref == 'refs/heads/Develop'
+    uses: "./.github/workflows/01_reactBuild.yml"
+
   build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/client/src/app/features/products/ProductsActions.tsx
+++ b/client/src/app/features/products/ProductsActions.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Paper,
-  Typography,
-} from "@mui/material";
+import { Box, Button, Paper, Typography } from "@mui/material";
 import { useNavigate } from "react-router";
 import { productsUri } from "../../routes/routesconsts";
 import AddToQueueIcon from "@mui/icons-material/AddToQueue";


### PR DESCRIPTION
Enabled artifact upload only on main branch in React build workflow. Added a step to build React on Develop branch in the .NET publish workflow. Cleaned up unused MUI imports in ProductsActions.tsx.